### PR TITLE
feat: add preinstall script to enforce pnpm usage as the package manager.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "preinstall": "npx only-allow pnpm",  
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -11,7 +12,7 @@
     "postinstall": "prisma generate",
     "prisma:migrate": "prisma migrate dev deploy",
     "prisma:docker": "pnpm prisma:migrate && pnpm postinstall",
-    "dev:docker": "pnpm prisma:docker & pnpm dev"
+    "dev:docker": "pnpm prisma:docker & pnpm dev",
     "format:fix": "prettier --write \"**/*.{ts,tsx,json}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,json}\""
   },


### PR DESCRIPTION
## This pr fixes the issue #34:
- ### Only allow pnpm as the package manager in the project

## Screenshots:

### Yarn:

<img width="1021" alt="Screenshot 2024-09-11 at 2 05 21 AM" src="https://github.com/user-attachments/assets/f502376c-3fd9-4d9c-ae1b-9b3114fa40c8"> <br />

### NPM:

<img width="1110" alt="Screenshot 2024-09-11 at 2 05 39 AM" src="https://github.com/user-attachments/assets/cb58e1c4-c73d-4cda-b52c-a7855ef20c18">
